### PR TITLE
make merge_bn.py compatible with Python3

### DIFF
--- a/merge_bn.py
+++ b/merge_bn.py
@@ -18,13 +18,17 @@ def merge_bn(net, nob):
     w = w * rstd * scale
     b = (b - mean) * rstd * scale + shift
     '''
-    for key in net.params.iterkeys():
+    if sys.version_info >= (3,0):
+        listKeys = net.params.keys()
+    else:
+        listKeys = net.params.iterkeys()
+    for key in listKeys:
         if type(net.params[key]) is caffe._caffe.BlobVec:
             if key.endswith("/bn") or key.endswith("/scale"):
 		continue
             else:
                 conv = net.params[key]
-                if not net.params.has_key(key + "/bn"):
+                if (key + "/bn") not in net.params:
                     for i, w in enumerate(conv):
                         nob.params[key][i].data[...] = w.data
                 else:


### PR DESCRIPTION
I didn't test it with Python2, but the changes didn't use something specific from Python3, so it should be compatible with Python>=2.7 and Python>=3.0

(Tested with Python3.5)