### PR TITLE
[create_lmdb] bug fix: wrong image size order

### DIFF
--- a/create_lmdb/code/create_list.sh
+++ b/create_lmdb/code/create_list.sh
@@ -67,7 +67,7 @@ done
 for i in ${arr[@]:${boundry}:((${length_imgs}-${boundry}))}
 do
 	line=`sed -n -e "${i}p" ${dst_all_tmp}|cut -d ' ' -f 1`
-	size=`identify ${data_root_dir}${line}|cut -d ' ' -f 3|sed -e "s/x/ /"`
+	size=`identify ${data_root_dir}${line}|cut -d ' ' -f 3|sed -e "s/x/ /" | sed -r 's/([^ ]+) (.*)/\2 \1/'`
 	echo ${line}
 	name=`basename ${line} .png`
 	echo ${name}" "${size} >> ${dst_file_test_name_size}


### PR DESCRIPTION
It's easy to check and reproduce this bug by replacing the "get_image_size" with "identify" in the origin [create_list.sh](https://github.com/weiliu89/caffe/blob/ssd/data/VOC0712/create_list.sh).
